### PR TITLE
error when watching a single region and single vpc

### DIFF
--- a/python/handlers.py
+++ b/python/handlers.py
@@ -250,8 +250,14 @@ def main(event, context):
                         region["RegionName"],
                     )
     else:
-        # Checking single AWS Region as VPC_ID and REGION_ID are NOT set
-        region_id = os.environ["REGION_ID"]
+        # Checking single AWS Region
+        if ("REGION_ID" not in os.environ or os.environ["REGION_ID"] == ""):
+            session = boto3.session.Session()
+            region_id = session.region_name
+            logging.info("os.environ[\"REGION_ID\"] not set, defaulting to region %s", region_id)
+        else: 
+            region_id = os.environ["REGION_ID"]
+
 
         # Get ENI count on this specific region
         enis_count = count_available_enis(region_id)
@@ -290,11 +296,16 @@ def main(event, context):
                         region_id,
                     )
         else:
-            vpc = vpc_client.Vpc(os.environ["VPC_ID"])
+            vpc_resource = boto3.resource("ec2", region_name=region_id)
+            vpc_object = vpc_resource.Vpc(os.environ["VPC_ID"])
 
             subnets_flagged = check_for_low_ips(
-                list(vpc.subnets.all()), vpc.vpc_id, region_id, count_enis
+                    list(vpc_object.subnets.all()),
+                    vpc_object.vpc_id,
+                    region_id,
+                    count_enis,
             )
+
 
     # Notifications
     if subnets_flagged:

--- a/python/handlers.py
+++ b/python/handlers.py
@@ -258,7 +258,6 @@ def main(event, context):
         else: 
             region_id = os.environ["REGION_ID"]
 
-
         # Get ENI count on this specific region
         enis_count = count_available_enis(region_id)
         count_enis.append(
@@ -305,7 +304,6 @@ def main(event, context):
                     region_id,
                     count_enis,
             )
-
 
     # Notifications
     if subnets_flagged:


### PR DESCRIPTION
I ran into an issue when specifying both the REGION_ID and VPC_ID. 

The error I got is:

```
[ERROR] AttributeError: 'EC2' object has no attribute 'Vpc'
Traceback (most recent call last):
  File "/var/task/subnet_watcher.py", line 293, in main
    vpc = vpc_client.Vpc(os.environ["VPC_ID"])
  File "/var/runtime/botocore/client.py", line 876, in __getattr__
    raise AttributeError(
```

It was a pretty simple fix and thought I'd open a PR in case anyone else is using it the same way. 

I also added lines 253-259 to set `region_id` to the current session region if the environment variable `REGION_ID` is not set. Those lines are not part of fixing the issue I had, and can be removed if you want to force setting `REGION_ID`. 

Thank you for sharing this project!



